### PR TITLE
Properly check column total is numeric when rendering

### DIFF
--- a/src/TotalsPlugin.js
+++ b/src/TotalsPlugin.js
@@ -44,7 +44,7 @@ TotalsPlugin.prototype.render = function () {
   
   for (var i = 0, l = columns.length; i < l; i++) {
     val = totals[columns[i].id];
-    cells[i].innerText = $.isNumeric(val) ? String(val) : '';
+    cells[i].innerText = $.isNumeric(val) ? val : '';
   }
 };
 

--- a/src/TotalsPlugin.js
+++ b/src/TotalsPlugin.js
@@ -40,9 +40,11 @@ TotalsPlugin.prototype.render = function () {
   var totals = this._grid.getData().getTotals();
   var columns = this._grid.getColumns();
   var cells = this._$totalsRow.children();
-
+  var val;
+  
   for (var i = 0, l = columns.length; i < l; i++) {
-    cells[i].innerText = totals[columns[i].id] || '';
+    val = totals[columns[i].id];
+    cells[i].innerText = $.isNumeric(val) ? String(val) : '';
   }
 };
 


### PR DESCRIPTION
This line in the render method will always pass back the empty string when totals[columns[i].id] == 0. That's because 0 is evaluated as false.

cells[i].innerText = totals[columns[i].id] || '';

Changed it to ensure the value is evaluated as a number.
